### PR TITLE
Add brightness control and text enhancements

### DIFF
--- a/lednamebadge_gui.py
+++ b/lednamebadge_gui.py
@@ -1,10 +1,21 @@
 import sys
 from array import array
 
-from PySide6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout,
-                               QGroupBox, QGridLayout, QLabel, QLineEdit,
-                               QSpinBox, QComboBox, QCheckBox, QPushButton,
-                               QTextEdit)
+from PySide6.QtWidgets import (
+    QApplication,
+    QMainWindow,
+    QWidget,
+    QVBoxLayout,
+    QGroupBox,
+    QGridLayout,
+    QLabel,
+    QPlainTextEdit,
+    QSpinBox,
+    QComboBox,
+    QCheckBox,
+    QPushButton,
+    QTextEdit,
+)
 
 from lednamebadge import SimpleTextAndIcons, LedNameBadge
 
@@ -18,15 +29,24 @@ class SlotWidget(QGroupBox):
 
         layout = QGridLayout(self)
 
-        self.text_edit = QLineEdit()
         layout.addWidget(QLabel("Text:"), 0, 0)
-        layout.addWidget(self.text_edit, 0, 1, 1, 3)
+        self.char_count_label = QLabel("0/750")
+        layout.addWidget(self.char_count_label, 0, 4)
+
+        self.text_edit = QPlainTextEdit()
+        self.text_edit.setLineWrapMode(QPlainTextEdit.WidgetWidth)
+        fm = self.text_edit.fontMetrics()
+        self.text_edit.setMinimumWidth(fm.averageCharWidth() * 75)
+        self.text_edit.setMinimumHeight(fm.lineSpacing() * 10)
+        layout.addWidget(self.text_edit, 1, 0, 1, 5)
+        self.text_edit.textChanged.connect(self._update_char_count)
+        self._update_char_count()
 
         self.speed_spin = QSpinBox()
         self.speed_spin.setRange(1, 8)
         self.speed_spin.setValue(4)
-        layout.addWidget(QLabel("Speed"), 1, 0)
-        layout.addWidget(self.speed_spin, 1, 1)
+        layout.addWidget(QLabel("Speed"), 2, 0)
+        layout.addWidget(self.speed_spin, 2, 1)
 
         self.mode_box = QComboBox()
         self.mode_box.addItem("Scroll left", 0)
@@ -38,22 +58,34 @@ class SlotWidget(QGroupBox):
         self.mode_box.addItem("Drop down", 6)
         self.mode_box.addItem("Curtain", 7)
         self.mode_box.addItem("Laser", 8)
-        layout.addWidget(QLabel("Mode"), 1, 2)
-        layout.addWidget(self.mode_box, 1, 3)
+        layout.addWidget(QLabel("Mode"), 2, 2)
+        layout.addWidget(self.mode_box, 2, 3)
 
         self.blink_box = QCheckBox("Blink")
-        layout.addWidget(self.blink_box, 2, 0)
+        layout.addWidget(self.blink_box, 3, 0)
         self.ants_box = QCheckBox("Ants")
-        layout.addWidget(self.ants_box, 2, 1)
+        layout.addWidget(self.ants_box, 3, 1)
 
     def values(self) -> dict:
         return {
-            "text": self.text_edit.text(),
+            "text": self.text_edit.toPlainText(),
             "speed": self.speed_spin.value(),
             "mode": self.mode_box.currentData(),
             "blink": 1 if self.blink_box.isChecked() else 0,
             "ants": 1 if self.ants_box.isChecked() else 0,
         }
+
+    def _update_char_count(self) -> None:
+        text = self.text_edit.toPlainText()
+        if len(text) > 750:
+            self.text_edit.blockSignals(True)
+            self.text_edit.setPlainText(text[:750])
+            cursor = self.text_edit.textCursor()
+            cursor.setPosition(750)
+            self.text_edit.setTextCursor(cursor)
+            self.text_edit.blockSignals(False)
+            text = self.text_edit.toPlainText()
+        self.char_count_label.setText(f"{len(text)}/750")
 
 
 class MainWindow(QMainWindow):
@@ -68,6 +100,20 @@ class MainWindow(QMainWindow):
         self.slots = [SlotWidget(i) for i in range(8)]
         for slot in self.slots:
             layout.addWidget(slot)
+
+        brightness_layout = QGridLayout()
+        brightness_widget = QWidget()
+        brightness_widget.setLayout(brightness_layout)
+
+        brightness_layout.addWidget(QLabel("Brightness"), 0, 0)
+        self.brightness_box = QComboBox()
+        self.brightness_box.addItem("25%", 25)
+        self.brightness_box.addItem("50%", 50)
+        self.brightness_box.addItem("75%", 75)
+        self.brightness_box.addItem("100%", 100)
+        self.brightness_box.setCurrentText("100%")
+        brightness_layout.addWidget(self.brightness_box, 0, 1)
+        layout.addWidget(brightness_widget)
 
         icons = ", ".join(f":{n}:" for n in SimpleTextAndIcons._get_named_bitmaps_keys())
         self.icons_desc = QTextEdit()
@@ -98,7 +144,8 @@ class MainWindow(QMainWindow):
             ants.append(v["ants"])
 
         lengths = [b[1] for b in msg_bitmaps]
-        header = LedNameBadge.header(lengths, speeds, modes, blinks, ants)
+        brightness = int(self.brightness_box.currentText().rstrip('%'))
+        header = LedNameBadge.header(lengths, speeds, modes, blinks, ants, brightness)
 
         buf = array('B')
         buf.extend(header)


### PR DESCRIPTION
## Summary
- Replace single-line slot inputs with large text areas limited to 750 characters
- Read brightness selection as an integer before writing to the badge

## Testing
- `cd tests && PYTHONPATH=.. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab52c173488331b7bae9b1affb2186